### PR TITLE
Swap assignment for binding

### DIFF
--- a/lib/Text/CSV.pm
+++ b/lib/Text/CSV.pm
@@ -82,7 +82,7 @@ class Text::CSV {
         }
         $parser.parse($input)
             or die "Sorry, cannot parse";
-        my @lines = $<line>;
+        my @lines := $<line>;
         my @values = map {
             [map { extract_text($_, $quote, :$trim) }, .<value>]
         }, @lines;


### PR DESCRIPTION
When I try to install Text::CSV now, I get an error from the tests:

> ===SORRY!===
> postcircumfix:<{ }> not defined for type Array

Tracked it down to line 85.  Here's my fix.  

You might want to forego the `@lines` array entirely and just use `$<line>.list` in the map statement on line 88.
